### PR TITLE
feat: support toolchain image with amd64/arm64 architectures

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,21 +30,18 @@ steps:
     image: autonomy/build-container:latest
     commands:
       - git fetch --tags
-      - apk add coreutils
-      - echo -e "$BUILDX_KUBECONFIG" > /root/.kube/config
-      - docker buildx create --driver kubernetes --driver-opt replicas=2 --driver-opt namespace=ci --driver-opt image=moby/buildkit:v0.6.2 --name ci --buildkitd-flags="--allow-insecure-entitlement security.insecure" --use
-      - docker buildx inspect --bootstrap
+      - install-ci-key
+      - setup-buildx-amd64-arm64
     environment:
-      BUILDX_KUBECONFIG:
-        from_secret: kubeconfig
-    privileged: true
+      SSH_KEY:
+        from_secret: ssh_key
     volumes:
       - name: docker-socket
         path: /var/run
       - name: docker
         path: /root/.docker/buildx
-      - name: kube
-        path: /root/.kube
+      - name: ssh
+        path: /root/.ssh
 
   - name: build-pull-request
     image: autonomy/build-container:latest
@@ -60,8 +57,8 @@ steps:
         path: /var/run
       - name: docker
         path: /root/.docker/buildx
-      - name: kube
-        path: /root/.kube
+      - name: ssh
+        path: /root/.ssh
 
   - name: build-and-publish
     image: autonomy/build-container:latest
@@ -83,15 +80,15 @@ steps:
         path: /var/run
       - name: docker
         path: /root/.docker/buildx
-      - name: kube
-        path: /root/.kube
+      - name: ssh
+        path: /root/.ssh
 
 volumes:
   - name: docker-socket
     temp: {}
   - name: docker
     temp: {}
-  - name: kube
+  - name: ssh
     temp: {}
 ---
 kind: pipeline

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 
 BUILD := docker buildx build
-PLATFORM ?= linux/amd64
+PLATFORM ?= linux/amd64,linux/arm64
 PROGRESS ?= auto
 PUSH ?= false
 COMMON_ARGS := --file=Pkgfile

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = docker.io/autonomy/bldr:v0.1.0-alpha.0-frontend
+# syntax = docker.io/autonomy/bldr:v0.2.0-alpha.0-frontend
 
 format: v1alpha2
 


### PR DESCRIPTION
Using new bldr frontend version which supports multi-arch images.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>