### PR TITLE
chore: update bldr frontend to 0.2.0-alpha.2.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = docker.io/autonomy/bldr:v0.2.0-alpha.0-frontend
+# syntax = docker.io/autonomy/bldr:v0.2.0-alpha.1-frontend
 
 format: v1alpha2
 


### PR DESCRIPTION
This brings in the fix for mutli-arch image manifests.

See https://github.com/talos-systems/bldr/pull/58

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>