### PR TITLE
fix: revert faccessat2 changes in libmusl 1.2.2

### DIFF
--- a/musl/patches/revert-faccessat2.patch
+++ b/musl/patches/revert-faccessat2.patch
@@ -1,0 +1,40 @@
+From 6c7fb5f32ad0fb2558d50cdaa39ff7fb0e95c58b Mon Sep 17 00:00:00 2001
+From: Ariadne Conill <ariadne@dereferenced.org>
+Date: Sat, 31 Oct 2020 06:26:46 -0600
+Subject: [PATCH] Revert "use new SYS_faccessat2 syscall to implement faccessat
+ with flags"
+
+This reverts commit 55fb9a177316aa46c639d93dd0323d9a9a8c160c.
+
+Causes too many problems on Alpine right now due to seccomp.
+---
+ src/unistd/faccessat.c | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/src/unistd/faccessat.c b/src/unistd/faccessat.c
+index 557503eb..76bbd4c7 100644
+--- a/src/unistd/faccessat.c
++++ b/src/unistd/faccessat.c
+@@ -25,17 +25,12 @@ static int checker(void *p)
+
+ int faccessat(int fd, const char *filename, int amode, int flag)
+ {
+-	if (flag) {
+-		int ret = __syscall(SYS_faccessat2, fd, filename, amode, flag);
+-		if (ret != -ENOSYS) return __syscall_ret(ret);
+-	}
++	if (!flag || (flag==AT_EACCESS && getuid()==geteuid() && getgid()==getegid()))
++		return syscall(SYS_faccessat, fd, filename, amode, flag);
+
+-	if (flag & ~AT_EACCESS)
++	if (flag != AT_EACCESS)
+ 		return __syscall_ret(-EINVAL);
+
+-	if (!flag || (getuid()==geteuid() && getgid()==getegid()))
+-		return syscall(SYS_faccessat, fd, filename, amode);
+-
+ 	char stack[1024];
+ 	sigset_t set;
+ 	pid_t pid;
+--
+2.29.2

--- a/musl/pkg.yaml
+++ b/musl/pkg.yaml
@@ -15,6 +15,8 @@ steps:
       - |
         tar -xzf musl.tar.gz --strip-components=1
 
+        patch -p1 < /pkg/patches/revert-faccessat2.patch
+
         mkdir build
         cd build
 


### PR DESCRIPTION
These changes cause issues with seccomp filters which don't include
faccessat2 syscall.

Patch from: https://git.alpinelinux.org/aports/commit/main/musl/?id=26f2d56ad63097cbc61c963ea91c9bd84a62eef4

See also:

* https://bugzilla.redhat.com/show_bug.cgi?id=1869030
* https://bugzilla.redhat.com/show_bug.cgi?id=1900021

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>