### PR TITLE
chore: update bldr version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 
 # Sync bldr image with Pkgfile
 BLDR ?= docker run --rm --volume $(PWD):/toolchain --entrypoint=/bldr \
-	ghcr.io/talos-systems/bldr:v0.2.0-alpha.3-frontend graph --root=/toolchain
+	ghcr.io/talos-systems/bldr:v0.2.0-alpha.4-frontend graph --root=/toolchain
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = ghcr.io/talos-systems/bldr:v0.2.0-alpha.3-frontend
+# syntax = ghcr.io/talos-systems/bldr:v0.2.0-alpha.4-frontend
 
 format: v1alpha2
 

--- a/musl/pkg.yaml
+++ b/musl/pkg.yaml
@@ -1,6 +1,7 @@
 name: musl
 install:
   - make
+  - patch
 dependencies:
   - stage: bootstrap
 steps:


### PR DESCRIPTION
Use v0.2.0-alpha.4 with the same version of musl.

Signed-off-by: Alexey Palazhchenko <alexey.palazhchenko@talos-systems.com>