### PR TITLE
feat: build binutils multi-arch

### DIFF
--- a/binutils/pkg.yaml
+++ b/binutils/pkg.yaml
@@ -28,7 +28,8 @@ steps:
         --with-lib-path=${TOOLCHAIN}/lib \
         --disable-nls \
         --disable-werror \
-        --enable-deterministic-archives
+        --enable-deterministic-archives \
+        --enable-targets=aarch64-linux-musl,aarch64_be-linux-musl,i686-linux-musl,x86_64-linux-musl,x86_64-linux-muslx32,x86_64-pep
     build:
       - |
         cd build


### PR DESCRIPTION
This makes `strip` process foreign architectures (in our case,
arm64/amd64 host/target).

See talos-systems/talos#4135

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>