### PR TITLE
backport: feat: build binutils multi-arch

### DIFF
--- a/binutils/pkg.yaml
+++ b/binutils/pkg.yaml
@@ -27,7 +27,8 @@ steps:
         --prefix=${TOOLCHAIN} \
         --with-lib-path=${TOOLCHAIN}/lib \
         --disable-nls \
-        --disable-werror
+        --disable-werror \
+        --enable-targets=aarch64-linux-musl,aarch64_be-linux-musl,i686-linux-musl,x86_64-linux-musl,x86_64-linux-muslx32,x86_64-pep
     build:
       - |
         cd build


### PR DESCRIPTION
This makes `strip` process foreign architectures (in our case,
arm64/amd64 host/target).

See talos-systems/talos#4135

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
(cherry picked from commit f7c10985b3b10060d54e1e3c702d9704475975e8)