### PR TITLE
fix: patch Linux headers for musl compatibility

### DIFF
--- a/linux-headers/patches/stddef.h-instead-of-compiler.h.patch
+++ b/linux-headers/patches/stddef.h-instead-of-compiler.h.patch
@@ -1,0 +1,26 @@
+See https://github.com/gentoo/musl/commit/e9a03616c762b689a02860e17347eb484d14addf
+
+From 9eb3c31415686ae1296d7d450f886eeba5861ec1 Mon Sep 17 00:00:00 2001
+From: Jory Pratt <anarchy@gentoo.org>
+Date: Thu, 3 Jun 2021 18:41:28 -0500
+Subject: [PATCH] Use stddefs.h instead of compiler.h
+
+---
+ include/uapi/linux/swab.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/uapi/linux/swab.h b/include/uapi/linux/swab.h
+index 7272f85..3736f2f 100644
+--- a/include/uapi/linux/swab.h
++++ b/include/uapi/linux/swab.h
+@@ -3,7 +3,7 @@
+ #define _UAPI_LINUX_SWAB_H
+
+ #include <linux/types.h>
+-#include <linux/compiler.h>
++#include <linux/stddef.h>
+ #include <asm/bitsperlong.h>
+ #include <asm/swab.h>
+
+--
+2.31.1

--- a/linux-headers/pkg.yaml
+++ b/linux-headers/pkg.yaml
@@ -1,6 +1,7 @@
 name: linux-headers
 install:
   - make
+  - patch
 dependencies:
   - stage: bootstrap
   - stage: musl
@@ -12,10 +13,13 @@ steps:
         sha512: "{{ .linux_sha512 }}"
     env:
       PATH: "{{ .BOOTSTRAP }}/bin:{{ .PATH }}"
-    build:
+    prepare:
       - |
         tar -xJf linux.tar.xz --strip-components=1
 
+        patch -p1 < /pkg/patches/stddef.h-instead-of-compiler.h.patch
+    build:
+      - |
         arch=""
 
         case $ARCH in


### PR DESCRIPTION
This fixes build failures for new Linux 5.15 kernel.

See also https://github.com/gentoo/musl/commit/e9a03616c762b689a02860e17347eb484d14addf

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>